### PR TITLE
Fixed the warning about accessing proptypes 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,6 @@
 'use strict';
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
+import PropTypes from 'prop-types';
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -72,8 +70,8 @@ function clickOutside(WrappedComponent) {
 
     return ClickOutside;
   }(_react.Component), _class.displayName = 'ClickOutside(' + (WrappedComponent.displayName || WrappedComponent.name || 'Component') + ')', _class.propTypes = {
-    onClickOutside: _react.PropTypes.func.isRequired
+    onClickOutside: PropTypes.func.isRequired
   }, _temp2;
 }
 
-exports.default = clickOutside;
+export default clickOutside;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 function clickOutside(WrappedComponent) {
   return class ClickOutside extends Component {


### PR DESCRIPTION
Implemented React 15.5 method that imports 'prop-types' module. Updated usage of exports.